### PR TITLE
[Feature/1202] create image api

### DIFF
--- a/images/serializers.py
+++ b/images/serializers.py
@@ -3,7 +3,7 @@ from posts.serializers import PostSerializer
 from .models import *
 
 class ImageSerializer(serializers.ModelSerializer):
-    post_id = PostSerializer(many=False,read_only=True)
+    post_id = PostSerializer()
     class Meta:
         model = Image
         fields = ['post_id', 'id', 'url']

--- a/images/serializers.py
+++ b/images/serializers.py
@@ -3,7 +3,6 @@ from posts.serializers import PostSerializer
 from .models import *
 
 class ImageSerializer(serializers.ModelSerializer):
-    post_id = PostSerializer()
     class Meta:
         model = Image
         fields = ['post_id', 'id', 'url']

--- a/images/serializers.py
+++ b/images/serializers.py
@@ -1,7 +1,9 @@
 from rest_framework import serializers
+from posts.serializers import PostSerializer
 from .models import *
 
 class ImageSerializer(serializers.ModelSerializer):
+    post_id = PostSerializer(many=False,read_only=True)
     class Meta:
         model = Image
         fields = ['post_id', 'id', 'url']

--- a/images/urls.py
+++ b/images/urls.py
@@ -5,14 +5,10 @@ from . import views
 app_name = 'images'
 
 urlpatterns = [
-    #  image create
-    path('create', views.create, name='create'),
-    # #  get > post images list
-    path('<int:post_id>/list', views.list, name='lists'),
-    #  get > image detail
+    # get => image list, post => create
+    path('<int:post_id>/list', views.list),
+    # get => detail, delete => delete image
     path('<int:id>', views.detail),
-    #  delete > image 
-    path('<int:id>', views.detail)
 ]
 
 urlpatterns = format_suffix_patterns(urlpatterns)

--- a/images/urls.py
+++ b/images/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
-from rest_framework.urlpatterns import format_suffix_patterns
 from . import views
+# rest framework import
+from rest_framework.urlpatterns import format_suffix_patterns
 
 app_name = 'images'
 

--- a/images/urls.py
+++ b/images/urls.py
@@ -5,7 +5,14 @@ from . import views
 app_name = 'images'
 
 urlpatterns = [
-    
+    #  image create
+    path('create', views.create, name='create'),
+    # #  get > post images list
+    path('<int:post_id>/list', views.list, name='lists'),
+    #  get > image detail
+    path('<int:id>', views.detail),
+    #  delete > image 
+    path('<int:id>', views.detail)
 ]
 
 urlpatterns = format_suffix_patterns(urlpatterns)

--- a/images/urls.py
+++ b/images/urls.py
@@ -7,9 +7,9 @@ app_name = 'images'
 
 urlpatterns = [
     # get => image list, post => create
-    path('<int:post_id>/list', views.list),
+    path('<int:post_id>/list', views.Imagelist.as_view()),
     # get => detail, delete => delete image
-    path('<int:id>', views.detail),
+    path('<int:id>', views.ImageDetail.as_view()),
 ]
 
 urlpatterns = format_suffix_patterns(urlpatterns)

--- a/images/urls.py
+++ b/images/urls.py
@@ -9,7 +9,8 @@ urlpatterns = [
     # get => image list, post => create
     path('<int:post_id>/list', views.Imagelist.as_view()),
     # get => detail, delete => delete image
-    path('<int:id>', views.ImageDetail.as_view()),
+    # genetic view 를 쓰면 무조건 pk 를 사용해야되나봄 
+    path('<int:pk>', views.ImageDetail.as_view()),
 ]
 
 urlpatterns = format_suffix_patterns(urlpatterns)

--- a/images/views.py
+++ b/images/views.py
@@ -10,7 +10,7 @@ from .serializers import ImageSerializer
 from rest_framework import mixins
 from rest_framework import generics
 
-class Imagelist(generics.ListCreateAPIView):
+class Imagelist(generics.CreateAPIView):
     queryset = Image.objects.all()
     serializer_class = ImageSerializer
     

--- a/images/views.py
+++ b/images/views.py
@@ -1,40 +1,43 @@
 # about image application import
+# about django rest framework import 
+# 1 -> 2 
+# remove json parser > response 
+# remove csrf exempt > api_view
 from .models import Image
 from posts.models import Post
 from .serializers import ImageSerializer
-# about django rest framework import
-from django.http import HttpResponse, JsonResponse
-from django.views.decorators.csrf import csrf_exempt
-from rest_framework.parsers import JSONParser
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
+from rest_framework import status
 
-# <post_id> images all 
-@csrf_exempt
-def list(request, post_id):
+
+@api_view(['GET', 'POST'])
+def list(request, post_id, format=None):
     if request.method == "GET":
         post = Post.objects.get(pk=post_id)
         images = Image.objects.filter(post_id=post)
         serializer = ImageSerializer(images, many=True)
-        return JsonResponse(serializer.data, safe=False)
+        return Response(serializer.data)
+
     elif request.method == "POST":
-        data = JSONParser().parse(request)
-        serializer = ImageSerializer(data=data)
+        serializer = ImageSerializer(data=request.data)
         if serializer.is_valid():
             serializer.save()
-            return JsonResponse(serializer.data, status=201)
-        return JsonResponse(serializer.errors, status=400)
+            return Response(serializer.data, status=status.HTTP_201_CREATED)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
-@csrf_exempt      
-def detail(request, id):
+@api_view(['GET', 'DELETE'])     
+def detail(request, id, format=None):
     try:
         image = Image.objects.get(pk=id)
     except Image.DoesNotExist:
-        return HttpResponse(status=404)
+        return Response(status=status.HTTP_404_NOT_FOUND)
 
     if request.method == "GET":
         serializer = ImageSerializer(image)
-        return JsonResponse(serializer.data)
+        return Response(serializer.data)
 
     elif request.method == "DELETE":
         image.delete()
-        return HttpResponse(status=204)
+        return Response(status=status.HTTP_204_NO_CONTENT)
 

--- a/images/views.py
+++ b/images/views.py
@@ -10,21 +10,10 @@ from .serializers import ImageSerializer
 from rest_framework import mixins
 from rest_framework import generics
 
-class Imagelist(mixins.ListModelMixin, mixins.CreateModelMixin, generics.GenericAPIView):
+class Imagelist(generics.ListCreateAPIView):
     queryset = Image.objects.all()
     serializer_class = ImageSerializer
     
-    def get(self, request, *args, **kwargs):
-            return self.list(request, *args, **kwargs)
-
-    def post(self, request, *args, **kwargs):
-        return self.create(request, *args, **kwargs)
-    
-class ImageDetail(mixins.RetrieveModelMixin, mixins.DestroyModelMixin, generics.GenericAPIView):
+class ImageDetail(generics.RetrieveDestroyAPIView):
     queryset = Image.objects.all()
     serializer_class = ImageSerializer
-    def get(self, request, *args, **kwargs):
-        return self.retrieve(request, *args, **kwargs)
-
-    def delete(self, request, *args, **kwargs):
-        return self.destroy(request, *args, **kwargs)

--- a/images/views.py
+++ b/images/views.py
@@ -1,43 +1,49 @@
 # about image application import
 # about django rest framework import 
-# 1 -> 2 
-# remove json parser > response 
-# remove csrf exempt > api_view
+# 2 -> 3 
+# add HTTP404
+# change apiview module import > decorate > viees
 from .models import Image
 from posts.models import Post
 from .serializers import ImageSerializer
-from rest_framework.decorators import api_view
+from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import status
+from django.http import Http404
 
+class Imagelist(APIView):
+    def valid_post_object(self,pk):
+        try:
+            return Post.objects.get(pk=pk)
+        except Post.DoesNotExist:
+            raise Http404
 
-@api_view(['GET', 'POST'])
-def list(request, post_id, format=None):
-    if request.method == "GET":
-        post = Post.objects.get(pk=post_id)
+    def get(self, request, post_id, format=None):
+        post = self.valid_post_object(post_id)
         images = Image.objects.filter(post_id=post)
         serializer = ImageSerializer(images, many=True)
         return Response(serializer.data)
 
-    elif request.method == "POST":
+    def post(self, request, post_id, format=None):
         serializer = ImageSerializer(data=request.data)
         if serializer.is_valid():
             serializer.save()
             return Response(serializer.data, status=status.HTTP_201_CREATED)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
-@api_view(['GET', 'DELETE'])     
-def detail(request, id, format=None):
-    try:
-        image = Image.objects.get(pk=id)
-    except Image.DoesNotExist:
-        return Response(status=status.HTTP_404_NOT_FOUND)
+class ImageDetail(APIView):
+    def get_object(self, id):
+        try:
+            return Image.objects.get(pk=id)
+        except Image.DoesNotExist:
+            raise Http404
 
-    if request.method == "GET":
-        serializer = ImageSerializer(image)
+    def get(self, request, id, format=None):
+        serializer = ImageSerializer(self.get_object(id))
         return Response(serializer.data)
 
-    elif request.method == "DELETE":
+    def delete(self, request, id, format=None):
+        image = self.get_object(id)
         image.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)
 

--- a/images/views.py
+++ b/images/views.py
@@ -1,3 +1,31 @@
 from django.shortcuts import render
+from posts.models import Post
+from django.views.decorators.csrf import csrf_exempt
+from .models import Image
 
-# Create your views here.
+
+@csrf_exempt
+def create(request):
+    # post 도 get 으로 바꿔야함
+    if request.method == "POST":
+        # post_id = 1 # dumy. 바꿔야함
+        post = Post.objects.get(pk=1)
+        image = Image.objects.create(post_id=post, url="https://github.com/jangjichang/Today-I-Learn/raw/master/Algorithm/theory/stack.jpg?raw=true")
+        return render(request, 'images/create.json', {'image': request.POST})
+
+def detail(request, id):
+    image = Image.objects.get(pk=id)
+    if request.method == "GET":
+        return render(request, 'images/detail.html', {'image':image})
+    
+    if request.method == "DELETE":
+        return render(request, 'images/delete.html', {'image':"image delete complete"})
+
+
+# 목록에 해당하는 사진 리스트만 반환한다
+def list(request,post_id):
+    if request.method == "GET":
+        post = Post.objects.get(pk=post_id)
+        images = Image.objects.filter(post_id=post)
+        if bool(images):
+            return render(request,'images/list.html',{'images' : images})

--- a/images/views.py
+++ b/images/views.py
@@ -3,47 +3,28 @@
 # 2 -> 3 
 # add HTTP404
 # change apiview module import > decorate > viees
+# remove and add mixins / generics
 from .models import Image
 from posts.models import Post
 from .serializers import ImageSerializer
-from rest_framework.views import APIView
-from rest_framework.response import Response
-from rest_framework import status
-from django.http import Http404
+from rest_framework import mixins
+from rest_framework import generics
 
-class Imagelist(APIView):
-    def valid_post_object(self,pk):
-        try:
-            return Post.objects.get(pk=pk)
-        except Post.DoesNotExist:
-            raise Http404
+class Imagelist(mixins.ListModelMixin, mixins.CreateModelMixin, generics.GenericAPIView):
+    queryset = Image.objects.all()
+    serializer_class = ImageSerializer
+    
+    def get(self, request, *args, **kwargs):
+            return self.list(request, *args, **kwargs)
 
-    def get(self, request, post_id, format=None):
-        post = self.valid_post_object(post_id)
-        images = Image.objects.filter(post_id=post)
-        serializer = ImageSerializer(images, many=True)
-        return Response(serializer.data)
+    def post(self, request, *args, **kwargs):
+        return self.create(request, *args, **kwargs)
+    
+class ImageDetail(mixins.RetrieveModelMixin, mixins.DestroyModelMixin, generics.GenericAPIView):
+    queryset = Image.objects.all()
+    serializer_class = ImageSerializer
+    def get(self, request, *args, **kwargs):
+        return self.retrieve(request, *args, **kwargs)
 
-    def post(self, request, post_id, format=None):
-        serializer = ImageSerializer(data=request.data)
-        if serializer.is_valid():
-            serializer.save()
-            return Response(serializer.data, status=status.HTTP_201_CREATED)
-        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
-
-class ImageDetail(APIView):
-    def get_object(self, id):
-        try:
-            return Image.objects.get(pk=id)
-        except Image.DoesNotExist:
-            raise Http404
-
-    def get(self, request, id, format=None):
-        serializer = ImageSerializer(self.get_object(id))
-        return Response(serializer.data)
-
-    def delete(self, request, id, format=None):
-        image = self.get_object(id)
-        image.delete()
-        return Response(status=status.HTTP_204_NO_CONTENT)
-
+    def delete(self, request, *args, **kwargs):
+        return self.destroy(request, *args, **kwargs)


### PR DESCRIPTION
- 게시글 기반 이미지 리스트 뽑아오기 (?)

- 이미지 등록 (O)
- 이미지 상세 (O)
- 이미지 삭제 (O)

기 중에 아래 3개를 구현했어. 

제너릭 뷰를 적용해버리니까, 특정한 post 값의 이미지 리스트가 아닌, 모든 이미지 리스트를 반환했다ㅠ_ㅠ
제너릭 뷰 기반에서 해버리려면 post serialize 에 아래를 넣고 (generic.ListView) 를 선언하면 한방에 해결될것 같은데, 지수랑 충돌 날까바 건들진 않고 image 쪽만 push 했어! 얘기하고 지수코드 머지하면 내가 풀 받아서 적용하든 할게!

불필요한 코드나 이상한거, 오타, 모르는거있음 코멘트 부탁해! 

```python
from rest_framework import serializers
from images.models import Image
from .models import *

class PostSerializer(serializers.ModelSerializer):
    images = serializers.PrimaryKeyRelatedField(many=True, queryset=Image.objects.all())

    class Meta:
        model = Post
        fields = ['user_id', 'id', 'title', 'thumbnail', 'status', 'images']
```
를 추가해야함. 그래서 post_id 가 1인 image list 를 불러오는건 posts 쪽에서 작업해야할듯. 

이건 제네릭 뷰를 쓰면 자동으로 지정되는거같아서, 같이 얘끼해볼 필요가 있을것 같아!